### PR TITLE
Aivot plugin for collision detection

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -95,6 +95,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
     backtrace/include
     collision_detection/include
     collision_detection_fcl/include
+    collision_detection_acl/include
     ${BULLET_INC}
     constraint_samplers/include
     controller_manager/include
@@ -133,6 +134,7 @@ catkin_package(
     moveit_planning_interface
     moveit_collision_detection
     moveit_collision_detection_fcl
+    moveit_collision_detection_acl
     ${BULLET_LIB}
     moveit_kinematic_constraints
     moveit_planning_scene
@@ -221,6 +223,7 @@ add_subdirectory(robot_state)
 add_subdirectory(robot_trajectory)
 add_subdirectory(collision_detection)
 add_subdirectory(collision_detection_fcl)
+add_subdirectory(collision_detection_acl)
 add_subdirectory(kinematic_constraints)
 add_subdirectory(planning_scene)
 add_subdirectory(constraint_samplers)

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -47,6 +47,8 @@ namespace collision_detection
 {
 MOVEIT_CLASS_FORWARD(CollisionEnv);  // Defines CollisionEnvPtr, ConstPtr, WeakPtr... etc
 
+typedef boost::function<void(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState&)> CollisionCallbackFn;
+
 /** \brief Provides the interface to the individual collision checking libraries. */
 class CollisionEnv
 {
@@ -74,6 +76,8 @@ public:
   virtual ~CollisionEnv()
   {
   }
+
+  virtual void setCollisionCallback(const CollisionCallbackFn& collCbkFn);
 
   /** @brief Check for robot self collision. Any collision between any pair of links is checked for, NO collisions are
    *   ignored.
@@ -319,6 +323,8 @@ protected:
 
   /** @brief The internally maintained map (from link names to scaling)*/
   std::map<std::string, double> link_scale_;
+
+  CollisionCallbackFn collCbkFn_;
 
 private:
   WorldPtr world_;             // The world always valid, never nullptr.

--- a/moveit_core/collision_detection/src/collision_env.cpp
+++ b/moveit_core/collision_detection/src/collision_env.cpp
@@ -70,7 +70,7 @@ static inline bool validatePadding(double padding)
 namespace collision_detection
 {
 CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
-  : robot_model_(model), world_(new World()), world_const_(world_)
+  : robot_model_(model), world_(new World()), world_const_(world_), collCbkFn_()
 {
   if (!validateScale(scale))
     scale = 1.0;
@@ -87,7 +87,7 @@ CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, double
 
 CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding,
                            double scale)
-  : robot_model_(model), world_(world), world_const_(world_)
+  : robot_model_(model), world_(world), world_const_(world_), collCbkFn_()
 {
   if (!validateScale(scale))
     scale = 1.0;
@@ -103,11 +103,18 @@ CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, const 
 }
 
 CollisionEnv::CollisionEnv(const CollisionEnv& other, const WorldPtr& world)
-  : robot_model_(other.robot_model_), world_(world), world_const_(world)
+  : robot_model_(other.robot_model_), world_(world), world_const_(world), collCbkFn_(other.collCbkFn_)
 {
   link_padding_ = other.link_padding_;
   link_scale_ = other.link_scale_;
 }
+
+void CollisionEnv::setCollisionCallback(const CollisionCallbackFn& collCbkFn)
+{
+    // derived classes need to explicitly support collision callbacks by overriding this method
+    assert(false);
+}
+
 void CollisionEnv::setPadding(double padding)
 {
   if (!validatePadding(padding))

--- a/moveit_core/collision_detection_acl/CMakeLists.txt
+++ b/moveit_core/collision_detection_acl/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(MOVEIT_LIB_NAME moveit_collision_detection_acl)
+
+add_library(${MOVEIT_LIB_NAME}
+  src/collision_common.cpp
+  src/collision_env_acl.cpp
+)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+
+
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
+
+add_library(collision_detector_acl_plugin src/collision_detector_acl_plugin_loader.cpp)
+set_target_properties(collision_detector_acl_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+target_link_libraries(collision_detector_acl_plugin ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} moveit_planning_scene)
+
+
+install(TARGETS ${MOVEIT_LIB_NAME} collision_detector_acl_plugin
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+install(FILES ../collision_detector_acl_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_common.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_common.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <moveit/collision_detection/world.h>
+#include <moveit/collision_detection/collision_env.h>
+#include <moveit/macros/class_forward.h>
+
+namespace collision_detection
+{
+MOVEIT_STRUCT_FORWARD(CollisionGeometryData);
+
+/** \brief Wrapper around world, link and attached objects' geometry data. */
+struct CollisionGeometryData
+{
+  /** \brief Constructor for a robot link collision geometry object. */
+  CollisionGeometryData(const moveit::core::LinkModel* link, int index)
+    : type(BodyTypes::ROBOT_LINK), shape_index(index)
+  {
+    ptr.link = link;
+  }
+
+  /** \brief Constructor for a new collision geometry object which is attached to the robot. */
+  CollisionGeometryData(const moveit::core::AttachedBody* ab, int index)
+    : type(BodyTypes::ROBOT_ATTACHED), shape_index(index)
+  {
+    ptr.ab = ab;
+  }
+
+  /** \brief Constructor for a new world collision geometry. */
+  CollisionGeometryData(const World::Object* obj, int index) : type(BodyTypes::WORLD_OBJECT), shape_index(index)
+  {
+    ptr.obj = obj;
+  }
+
+  /** \brief Returns the name which is saved in the member pointed to in \e ptr. */
+  const std::string& getID() const
+  {
+    switch (type)
+    {
+      case BodyTypes::ROBOT_LINK:
+        return ptr.link->getName();
+      case BodyTypes::ROBOT_ATTACHED:
+        return ptr.ab->getName();
+      default:
+        break;
+    }
+    return ptr.obj->id_;
+  }
+
+  /** \brief Returns a string of the corresponding \e type. */
+  std::string getTypeString() const
+  {
+    switch (type)
+    {
+      case BodyTypes::ROBOT_LINK:
+        return "Robot link";
+      case BodyTypes::ROBOT_ATTACHED:
+        return "Robot attached";
+      default:
+        break;
+    }
+    return "Object";
+  }
+
+  /** \brief Check if two CollisionGeometryData objects point to the same source object. */
+  bool sameObject(const CollisionGeometryData& other) const
+  {
+    return type == other.type && ptr.raw == other.ptr.raw;
+  }
+
+  /** \brief Indicates the body type of the object. */
+  BodyType type;
+
+  /** \brief Multiple \e CollisionGeometryData objects construct a collision object. The collision object refers to an
+   *  array of coordinate transformations at a certain start index. The index of the transformation of a child \e
+   *  CollisionGeometryData object is then given by adding the parent collision object index and the \e shape_index of a
+   *  geometry data object. */
+  int shape_index;
+
+  /** \brief Points to the type of body which contains the geometry. */
+  union
+  {
+    const moveit::core::LinkModel* link;
+    const moveit::core::AttachedBody* ab;
+    const World::Object* obj;
+    const void* raw;
+  } ptr;
+};
+
+/** \brief Data structure which is passed to the collision callback function of the collision manager. */
+struct CollisionData
+{
+  CollisionData() : req_(nullptr), active_components_only_(nullptr), res_(nullptr), acm_(nullptr), done_(false)
+  {
+  }
+
+  CollisionData(const CollisionRequest* req, CollisionResult* res, const AllowedCollisionMatrix* acm)
+    : req_(req), active_components_only_(nullptr), res_(res), acm_(acm), done_(false)
+  {
+  }
+
+  ~CollisionData()
+  {
+  }
+
+  /** \brief Compute \e active_components_only_ based on the joint group specified in \e req_ */
+  void enableGroup(const moveit::core::RobotModelConstPtr& robot_model);
+
+  /** \brief The collision request passed by the user */
+  const CollisionRequest* req_;
+
+  /** \brief  If the collision request includes a group name, this set contains the pointers to the link models that
+   *  are considered for collision.
+   *
+   *  If the pointer is NULL, all collisions are considered. */
+  const std::set<const moveit::core::LinkModel*>* active_components_only_;
+
+  /** \brief The user-specified response location. */
+  CollisionResult* res_;
+
+  /** \brief The user-specified collision matrix (may be NULL). */
+  const AllowedCollisionMatrix* acm_;
+
+  /** \brief Flag indicating whether collision checking is complete. */
+  bool done_;
+};
+
+/** \brief Data structure which is passed to the distance callback function of the collision manager. */
+struct DistanceData
+{
+  DistanceData(const DistanceRequest* req, DistanceResult* res) : req(req), res(res), done(false)
+  {
+  }
+  ~DistanceData()
+  {
+  }
+
+  /** \brief Distance query request information. */
+  const DistanceRequest* req;
+
+  /** \brief Distance query results information. */
+  DistanceResult* res;
+
+  /** \brief Indicates if distance query is finished. */
+  bool done;
+};
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_acl_plugin_loader.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_acl_plugin_loader.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <moveit/collision_detection/collision_plugin.h>
+#include <moveit/collision_detection_acl/collision_detector_allocator_acl.h>
+
+namespace collision_detection
+{
+class CollisionDetectorACLPluginLoader : public CollisionPlugin
+{
+public:
+  bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const override;
+};
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_allocator_acl.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_allocator_acl.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <rosconsole/macros_generated.h>
+#include <moveit/collision_detection/collision_detector_allocator.h>
+#include <moveit/collision_detection_acl/collision_env_acl.h>
+
+namespace collision_detection
+{
+/** \brief An allocator for ACL collision detectors */
+class CollisionDetectorAllocatorACL
+  : public CollisionDetectorAllocatorTemplate<CollisionEnvACL, CollisionDetectorAllocatorACL>
+{
+public:
+  const std::string& getName() const override;
+};
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
@@ -3,7 +3,6 @@
 #include <moveit/collision_detection/collision_env.h>
 #include <moveit/collision_detection_acl/collision_common.h>
 
-#include <thor_moveit_config/LinkPosShiftArray.h>
 #include "moveit/profiler/profiler.h"
 
 namespace collision_detection

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <moveit/collision_detection/collision_env.h>
+#include <moveit/collision_detection_acl/collision_common.h>
+
+#include <thor_moveit_config/LinkPosShiftArray.h>
+#include "moveit/profiler/profiler.h"
+
+namespace collision_detection
+{
+/** \brief ACL implementation of the CollisionEnv */
+class CollisionEnvACL : public CollisionEnv
+{
+public:
+  CollisionEnvACL() = delete;
+
+  CollisionEnvACL(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+
+  CollisionEnvACL(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
+                  double scale = 1.0);
+
+  CollisionEnvACL(const CollisionEnvACL& other, const WorldPtr& world);
+
+  ~CollisionEnvACL() override;
+
+  void setCollisionCallback(const collision_detection::CollisionCallbackFn& collFn);
+
+  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                          const moveit::core::RobotState& state) const override;
+
+  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
+                          const AllowedCollisionMatrix& acm) const override;
+
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                           const moveit::core::RobotState& state) const override;
+
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
+                           const AllowedCollisionMatrix& acm) const override;
+
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state1,
+                           const moveit::core::RobotState& state2, const AllowedCollisionMatrix& acm) const override;
+
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state1,
+                           const moveit::core::RobotState& state2) const override;
+
+  void distanceSelf(const DistanceRequest& req, DistanceResult& res,
+                    const moveit::core::RobotState& state) const override;
+
+  void distanceRobot(const DistanceRequest& req, DistanceResult& res,
+                     const moveit::core::RobotState& state) const override;
+
+  void setWorld(const WorldPtr& world) override;
+
+protected:
+
+  /** \brief Bundles the different checkSelfCollision functions into a single function */
+  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm) const;
+
+  /** \brief Bundles the different checkRobotCollision functions into a single function */
+  void checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                 const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm) const;
+
+private:
+  /** \brief Callback function executed for each change to the world environment */
+  void notifyObjectChange(const ObjectConstPtr& obj, World::Action action);
+
+  World::ObserverHandle observer_handle_;
+  std::map<std::string, Eigen::Vector3d> linkPosShiftMap_;
+  moveit::tools::Profiler profiler_;
+};
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_acl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_acl/src/collision_common.cpp
@@ -1,0 +1,12 @@
+#include <moveit/collision_detection_acl/collision_common.h>
+
+namespace collision_detection
+{
+void CollisionData::enableGroup(const moveit::core::RobotModelConstPtr& robot_model)
+{
+  if (robot_model->hasJointModelGroup(req_->group_name))
+    active_components_only_ = &robot_model->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsSet();
+  else
+    active_components_only_ = nullptr;
+}
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_acl/src/collision_detector_acl_plugin_loader.cpp
+++ b/moveit_core/collision_detection_acl/src/collision_detector_acl_plugin_loader.cpp
@@ -1,0 +1,13 @@
+#include <moveit/collision_detection_acl/collision_detector_acl_plugin_loader.h>
+#include <pluginlib/class_list_macros.h>
+
+namespace collision_detection
+{
+bool CollisionDetectorACLPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const
+{
+  scene->setActiveCollisionDetector(CollisionDetectorAllocatorACL::create(), exclusive);
+  return true;
+}
+}  // namespace collision_detection
+
+PLUGINLIB_EXPORT_CLASS(collision_detection::CollisionDetectorACLPluginLoader, collision_detection::CollisionPlugin)

--- a/moveit_core/collision_detection_acl/src/collision_env_acl.cpp
+++ b/moveit_core/collision_detection_acl/src/collision_env_acl.cpp
@@ -1,0 +1,189 @@
+#include <moveit/collision_detection_acl/collision_env_acl.h>
+#include <moveit/collision_detection_acl/collision_detector_allocator_acl.h>
+#include <moveit/collision_detection_acl/collision_common.h>
+
+namespace collision_detection
+{
+static const std::string NAME = "ACL";
+constexpr char LOGNAME[] = "collision_detection.acl";
+
+CollisionEnvACL::CollisionEnvACL(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
+  : CollisionEnv(model, padding, scale)
+  , profiler_(true)
+{
+
+
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(
+      [this](const World::ObjectConstPtr& object, World::Action action) { notifyObjectChange(object, action); });
+}
+
+CollisionEnvACL::CollisionEnvACL(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding,
+                                 double scale)
+  : CollisionEnv(model, world, padding, scale)
+  , profiler_(true)
+{
+
+
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(
+      [this](const World::ObjectConstPtr& object, World::Action action) { notifyObjectChange(object, action); });
+  getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
+}
+
+CollisionEnvACL::~CollisionEnvACL()
+{
+  getWorld()->removeObserver(observer_handle_);
+}
+
+CollisionEnvACL::CollisionEnvACL(const CollisionEnvACL& other, const WorldPtr& world)
+  : CollisionEnv(other, world)
+  , profiler_(true)
+{
+
+
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(
+      [this](const World::ObjectConstPtr& object, World::Action action) { notifyObjectChange(object, action); });
+}
+
+void CollisionEnvACL::setCollisionCallback(const collision_detection::CollisionCallbackFn& collCbkFn)
+{
+  ROS_DEBUG_NAMED(LOGNAME, "setting CollisionCallback in Env obj %x", this);
+  collCbkFn_ = collCbkFn;
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "collCbkFn is now " << collCbkFn_);
+}
+
+void CollisionEnvACL::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                         const moveit::core::RobotState& state) const
+{
+  checkSelfCollisionHelper(req, res, state, nullptr);
+}
+
+void CollisionEnvACL::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                         const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const
+{
+  checkSelfCollisionHelper(req, res, state, &acm);
+}
+
+void CollisionEnvACL::checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                               const moveit::core::RobotState& state,
+                                               const AllowedCollisionMatrix* acm) const
+{
+  ROS_DEBUG_ONCE_NAMED(LOGNAME, "checkSelfCollision");
+
+  if (collCbkFn_.empty()) {
+    return;
+  }
+  moveit::tools::Profiler& prof = const_cast<moveit::tools::Profiler&>(profiler_);
+  prof.begin("self_collision");
+
+  collCbkFn_(req, res, state);
+
+  prof.end("self_collision");
+}
+
+void CollisionEnvACL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                          const moveit::core::RobotState& state) const
+{
+  checkRobotCollisionHelper(req, res, state, nullptr);
+}
+
+void CollisionEnvACL:: checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                          const moveit::core::RobotState& state,
+                                          const AllowedCollisionMatrix& acm) const
+{
+  checkRobotCollisionHelper(req, res, state, &acm);
+}
+
+void CollisionEnvACL::checkRobotCollision(const CollisionRequest& /*req*/, CollisionResult& /*res*/,
+                                          const moveit::core::RobotState& /*state1*/,
+                                          const moveit::core::RobotState& /*state2*/) const
+{
+  ROS_ERROR_NAMED(LOGNAME, "Continuous collision not implemented");
+}
+
+void CollisionEnvACL::checkRobotCollision(const CollisionRequest& /*req*/, CollisionResult& /*res*/,
+                                          const moveit::core::RobotState& /*state1*/,
+                                          const moveit::core::RobotState& /*state2*/,
+                                          const AllowedCollisionMatrix& /*acm*/) const
+{
+  ROS_ERROR_NAMED(LOGNAME, "Not implemented");
+}
+
+void CollisionEnvACL::checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                                const moveit::core::RobotState& state,
+                                                const AllowedCollisionMatrix* acm) const
+{
+  assert(!collCbkFn_.empty());
+  ROS_DEBUG_ONCE_NAMED(LOGNAME, "checkRobotCollision");
+
+  moveit::tools::Profiler& prof = const_cast<moveit::tools::Profiler&>(profiler_);
+  prof.begin("robot_collision");
+
+  collCbkFn_(req, res, state);
+
+  prof.end("robot_collision");
+
+  if (req.distance)
+  {
+    assert(false);
+  }
+}
+
+void CollisionEnvACL::distanceSelf(const DistanceRequest& req, DistanceResult& res,
+                                   const moveit::core::RobotState& state) const
+{
+  // TODO
+}
+
+void CollisionEnvACL::distanceRobot(const DistanceRequest& req, DistanceResult& res,
+                                    const moveit::core::RobotState& state) const
+{
+  // TODO
+}
+
+void CollisionEnvACL::setWorld(const WorldPtr& world)
+{
+  if (world == getWorld())
+    return;
+
+  // turn off notifications about old world
+  getWorld()->removeObserver(observer_handle_);
+
+
+
+
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(
+      [this](const World::ObjectConstPtr& object, World::Action action) { notifyObjectChange(object, action); });
+
+  // get notifications any objects already in the new world
+  getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
+}
+
+void CollisionEnvACL::notifyObjectChange(const ObjectConstPtr& obj, World::Action action)
+{
+  if (action == World::DESTROY)
+  {
+
+
+
+  }
+  else
+  {
+    if (action & (World::DESTROY | World::REMOVE_SHAPE))
+    {
+    }
+
+
+
+
+  }
+}
+
+const std::string& CollisionDetectorAllocatorACL::getName() const
+{
+  return NAME;
+}
+}  // namespace collision_detection

--- a/moveit_core/collision_detector_acl_description.xml
+++ b/moveit_core/collision_detector_acl_description.xml
@@ -1,0 +1,8 @@
+<library path="lib/libcollision_detector_acl_plugin">
+  <class name="ACL" type="collision_detection::CollisionDetectorACLPluginLoader"
+  base_class_type="collision_detection::CollisionPlugin">
+    <description>
+      ACL Collision Detector, build by Aivot
+    </description>
+  </class>
+</library>

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -68,6 +68,7 @@
 
   <export>
     <moveit_core plugin="${prefix}/collision_detector_fcl_description.xml"/>
+    <moveit_core plugin="${prefix}/collision_detector_acl_description.xml"/>
     <moveit_core plugin="${prefix}/collision_detector_bullet_description.xml"/>
   </export>
 </package>


### PR DESCRIPTION
Created a collision plugin for Aivot, which will be used as the exclusive collision detector. aivot_motion registers a callback with this detector plugin, which gets invoked by MoveIt's PlanningScene::checkCollision(). 