### PR TITLE
Fix monitored planning scene updates

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -376,11 +376,17 @@ void PlanningSceneMonitor::scenePublishingThread()
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneDiffMsg(msg);
-            if (new_scene_update_ == UPDATE_STATE)
-            {
-              msg.robot_state.attached_collision_objects.clear();
-              msg.robot_state.is_diff = true;
-            }
+            // always send robot_state as full update (for now).
+            // getPlanningSceneDiffMsg may add entries to the sceneMsg based
+            // on current (full) robot_state and world_diff, and this can
+            // happen irrespective of new_scene_update_. Clearing
+            // attached_collision_objects and sending robot_state as diff will
+            // cause these changes to be lost.
+//            if (new_scene_update_ == UPDATE_STATE)
+//            {
+//              msg.robot_state.attached_collision_objects.clear();
+//              msg.robot_state.is_diff = true;
+//            }
           }
           boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_);  // we don't want the
                                                                                                  // transform cache to


### PR DESCRIPTION

**Issue Description**
When `moveit::core::PlanningScene` generates a scene diff message, it uses current full robot state (since `robot_state` doesn't support diffs)  and `world` state diff to construct additional entries required to reflect changes to robot state. 

PlanningSceneMonitor (PSM) monitors changes to robot_state, scene geometry, transformations, etc., and publishes a "monitored scene" for clients to consume. To do this, it fetches the `moveit_msgs::PlanningScene` message generated by `moveit::core::PlanningScene`, then massages it depending on the nature of changes that occurred to the monitored scene. There are multiple entry-points to update the monitored scene though (LockedPlanningSceneRW, publishing scene changes to a topic that PSM listens on, etc.), and there is no unified mechanism in PSM to track all changes through these different entry points. As a result, the message massaging by PSM could result in some scene changes not getting propagated to listeners (RViz, planners, etc.).

**Fix**
Always send `robot_state` updates as full updates (not diffs). It may be possible to improve this with unified scene/robot state change tracking in PSM, but that is an exercise for later. 