### PR TITLE
CollisionDetectorACL: Delegates self-collision check to callback

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -47,8 +47,6 @@ namespace collision_detection
 {
 MOVEIT_CLASS_FORWARD(CollisionEnv);  // Defines CollisionEnvPtr, ConstPtr, WeakPtr... etc
 
-typedef boost::function<void(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState&)> CollisionCallbackFn;
-
 /** \brief Provides the interface to the individual collision checking libraries. */
 class CollisionEnv
 {
@@ -76,8 +74,6 @@ public:
   virtual ~CollisionEnv()
   {
   }
-
-  virtual void setCollisionCallback(const CollisionCallbackFn& collCbkFn);
 
   /** @brief Check for robot self collision. Any collision between any pair of links is checked for, NO collisions are
    *   ignored.
@@ -323,8 +319,6 @@ protected:
 
   /** @brief The internally maintained map (from link names to scaling)*/
   std::map<std::string, double> link_scale_;
-
-  CollisionCallbackFn collCbkFn_;
 
 private:
   WorldPtr world_;             // The world always valid, never nullptr.

--- a/moveit_core/collision_detection/src/collision_env.cpp
+++ b/moveit_core/collision_detection/src/collision_env.cpp
@@ -70,7 +70,7 @@ static inline bool validatePadding(double padding)
 namespace collision_detection
 {
 CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
-  : robot_model_(model), world_(new World()), world_const_(world_), collCbkFn_()
+  : robot_model_(model), world_(new World()), world_const_(world_)
 {
   if (!validateScale(scale))
     scale = 1.0;
@@ -87,7 +87,7 @@ CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, double
 
 CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding,
                            double scale)
-  : robot_model_(model), world_(world), world_const_(world_), collCbkFn_()
+  : robot_model_(model), world_(world), world_const_(world_)
 {
   if (!validateScale(scale))
     scale = 1.0;
@@ -103,16 +103,10 @@ CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, const 
 }
 
 CollisionEnv::CollisionEnv(const CollisionEnv& other, const WorldPtr& world)
-  : robot_model_(other.robot_model_), world_(world), world_const_(world), collCbkFn_(other.collCbkFn_)
+  : robot_model_(other.robot_model_) , world_(world) , world_const_(world)
 {
   link_padding_ = other.link_padding_;
   link_scale_ = other.link_scale_;
-}
-
-void CollisionEnv::setCollisionCallback(const CollisionCallbackFn& collCbkFn)
-{
-    // derived classes need to explicitly support collision callbacks by overriding this method
-    assert(false);
 }
 
 void CollisionEnv::setPadding(double padding)

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_callback.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_callback.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <moveit/collision_detection/collision_common.h>
+
+namespace collision_detection::acl {
+
+    MOVEIT_CLASS_FORWARD(CollisionCallback);
+
+    class CollisionCallback
+    {
+    public:
+        virtual ~CollisionCallback() = default;
+
+        virtual void checkSelfCollision(const CollisionRequest &req, CollisionResult &res, const moveit::core::RobotState &state) = 0;
+        virtual void checkRobotCollision(const CollisionRequest &req, CollisionResult &res, const moveit::core::RobotState &state) = 0;
+    };
+}

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_allocator_acl.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_allocator_acl.h
@@ -6,11 +6,37 @@
 
 namespace collision_detection
 {
+
+MOVEIT_CLASS_FORWARD(CollisionDetectorAllocatorACL);  // Defines CollisionDetectorAllocatorACLPtr, ConstPtr, WeakPtr... etc
+
 /** \brief An allocator for ACL collision detectors */
 class CollisionDetectorAllocatorACL
   : public CollisionDetectorAllocatorTemplate<CollisionEnvACL, CollisionDetectorAllocatorACL>
+  , public collision_detection::acl::CollisionCallback
+  , public std::enable_shared_from_this<collision_detection::acl::CollisionCallback>
 {
 public:
+  CollisionEnvPtr allocateEnv(const WorldPtr& world, const moveit::core::RobotModelConstPtr& robot_model) const override;
+
+  CollisionEnvPtr allocateEnv(const moveit::core::RobotModelConstPtr& robot_model) const override;
+
   const std::string& getName() const override;
+
+  void setCollisionCallback(const collision_detection::acl::CollisionCallbackPtr& collisionCallback) {
+      collisionCallback_ = collisionCallback;
+  }
+
+  virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state) override {
+    assert(collisionCallback_ && "No collision callback is set!");
+    collisionCallback_->checkRobotCollision(req, res, state);
+  }
+
+  virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state) override {
+      assert(collisionCallback_ && "No collision callback is set!");
+      collisionCallback_->checkSelfCollision(req, res, state);
+  }
+
+private:
+    acl::CollisionCallbackPtr collisionCallback_;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
@@ -4,6 +4,7 @@
 
 #include "moveit/profiler/profiler.h"
 #include "moveit/collision_detection_fcl/collision_env_fcl.h"
+#include "moveit/collision_detection_acl/collision_callback.h"
 
 namespace collision_detection
 {
@@ -13,16 +14,15 @@ class CollisionEnvACL : public CollisionEnvFCL
 public:
   CollisionEnvACL() = delete;
 
-  CollisionEnvACL(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+  CollisionEnvACL(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world,
+                  const collision_detection::acl::CollisionCallbackPtr& collisionCallback = {});
 
-  CollisionEnvACL(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
-                  double scale = 1.0);
+  CollisionEnvACL(const moveit::core::RobotModelConstPtr& model,
+                  const collision_detection::acl::CollisionCallbackPtr& collisionCallback = {});
 
   CollisionEnvACL(const CollisionEnvACL& other, const WorldPtr& world);
 
   ~CollisionEnvACL() override;
-
-  void setCollisionCallback(const collision_detection::CollisionCallbackFn& collFn);
 
   void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
                           const moveit::core::RobotState& state) const override;
@@ -59,5 +59,8 @@ protected:
   /** \brief Bundles the different checkRobotCollision functions into a single function */
   void checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
                                  const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm) const;
+private:
+  /** @brief The callback to perform collision checks */
+  acl::CollisionCallbackPtr collisionCallback_;
 };
 }  // namespace collision_detection

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -680,7 +680,11 @@ bool IKConstraintSampler::callIK(const geometry_msgs::Pose& ik_query,
       solution[ik_joint_bijection[i]] = ik_sol[i];
     state.setJointGroupPositions(jmg_, solution);
 
-    return validate(state);
+    bool valid = validate(state);
+    if(!valid) {
+        moveit::tools::Profiler::Event("IKConstraintSampler::invalidIK");
+    }
+    return valid;
   }
   else
   {
@@ -691,6 +695,7 @@ bool IKConstraintSampler::callIK(const geometry_msgs::Pose& ik_query,
     else if (verbose_)
       ROS_INFO_NAMED("constraint_samplers", "IK failed");
   }
+  moveit::tools::Profiler::Event("IKConstraintSampler::noIK");
   return false;
 }
 


### PR DESCRIPTION
* Added `ColllisionCallback` interface as a replacement for `CollisionCallbackFn` used previously
* Callback registration is done via `CollisionDetectrorAllocatorACL` 
* Additional profiler stats in `IKConstraintedSampler`
