### PR TITLE
Aivot Start State Collision Adapter

### DIFF
--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_callback.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_callback.h
@@ -12,5 +12,6 @@ namespace collision_detection::acl {
 
         virtual void checkSelfCollision(const CollisionRequest &req, CollisionResult &res, const moveit::core::RobotState &state) = 0;
         virtual void checkRobotCollision(const CollisionRequest &req, CollisionResult &res, const moveit::core::RobotState &state) = 0;
+        virtual std::vector<moveit::core::RobotState> getUnstuckPath(const moveit::core::RobotState& startState) = 0;
     };
 }

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_allocator_acl.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_detector_allocator_acl.h
@@ -36,7 +36,12 @@ public:
       collisionCallback_->checkSelfCollision(req, res, state);
   }
 
+  virtual std::vector<moveit::core::RobotState> getUnstuckPath(const moveit::core::RobotState& startState) override {
+      assert(collisionCallback_ && "No collision callback is set!");
+      return collisionCallback_->getUnstuckPath(startState);
+  }
+
 private:
-    acl::CollisionCallbackPtr collisionCallback_;
+  acl::CollisionCallbackPtr collisionCallback_;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
+++ b/moveit_core/collision_detection_acl/include/moveit/collision_detection_acl/collision_env_acl.h
@@ -42,6 +42,8 @@ public:
   void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state1,
                            const moveit::core::RobotState& state2) const override;
 
+  std::vector<moveit::core::RobotState> getUnstuckPath(const moveit::core::RobotState& startState) const;
+
   void distanceSelf(const DistanceRequest& req, DistanceResult& res,
                     const moveit::core::RobotState& state) const override;
 

--- a/moveit_core/collision_detection_acl/src/collision_env_acl.cpp
+++ b/moveit_core/collision_detection_acl/src/collision_env_acl.cpp
@@ -89,6 +89,14 @@ void CollisionEnvACL::checkRobotCollisionHelper(const CollisionRequest& req, Col
   }
 }
 
+std::vector<moveit::core::RobotState> CollisionEnvACL::getUnstuckPath(const moveit::core::RobotState& startState) const
+{
+    moveit::tools::Profiler::ScopedBlock sblock("CollisionEnvACL::getUnstuckPath");
+
+    assert(collisionCallback_ && "Robot collision callback must be set!");
+    return collisionCallback_->getUnstuckPath(startState);
+}
+
 void CollisionEnvACL::distanceSelf(const DistanceRequest& req, DistanceResult& res,
                                    const moveit::core::RobotState& state) const
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCE_FILES
   src/empty.cpp
   src/fix_start_state_bounds.cpp
   src/fix_start_state_collision.cpp
+  src/aivot_fix_start_state_collision.cpp
   src/fix_start_state_path_constraints.cpp
   src/fix_workspace_bounds.cpp
   src/add_time_parameterization.cpp

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/aivot_fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/aivot_fix_start_state_collision.cpp
@@ -1,6 +1,8 @@
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <class_loader/class_loader.hpp>
 #include <ros/ros.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit/collision_detection_acl/collision_env_acl.h>
 
 namespace default_planner_request_adapters
 {
@@ -9,13 +11,21 @@ namespace default_planner_request_adapters
     class AivotFixStartStateCollision : public planning_request_adapter::PlanningRequestAdapter
     {
     public:
+        static const std::string DT_PARAM_NAME;
+
         AivotFixStartStateCollision()
                 : planning_request_adapter::PlanningRequestAdapter()
         {}
 
-        void initialize(const ros::NodeHandle& nh) override
-        {
+        void initialize(const ros::NodeHandle& nh) override {
             ROS_INFO_NAMED(LOGNAME, "Initializing '%s'", getDescription().c_str());
+
+            if (!nh.getParam(DT_PARAM_NAME, max_dt_offset_)) {
+                max_dt_offset_ = 0.5;
+                ROS_INFO_STREAM_NAMED(LOGNAME, "Param '" << DT_PARAM_NAME << "' was not set. Using default value: " << max_dt_offset_);
+            } else {
+                ROS_INFO_STREAM_NAMED(LOGNAME, "Param '" << DT_PARAM_NAME << "' was set to " << max_dt_offset_);
+            }
         }
 
         std::string getDescription() const override
@@ -28,11 +38,82 @@ namespace default_planner_request_adapters
                           std::vector<std::size_t>& added_path_index) const override
         {
             ROS_INFO_NAMED(LOGNAME, "Running '%s'", getDescription().c_str());
-            return planner(planning_scene, req, res);
+
+            // get the specified start state
+            moveit::core::RobotState start_state = planning_scene->getCurrentState();
+            moveit::core::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
+
+            collision_detection::CollisionRequest creq;
+            creq.group_name = req.group_name;
+            collision_detection::CollisionResult cres;
+            planning_scene->checkCollision(creq, cres, start_state);
+            if (cres.collision)
+            {
+                if (creq.group_name.empty()) {
+                    ROS_INFO_NAMED(LOGNAME, "Start state appears to be in collision");
+                } else {
+                    ROS_INFO_STREAM_NAMED(LOGNAME, "Start state appears to be in collision with respect to group "
+                            << creq.group_name);
+                }
+
+                const collision_detection::CollisionEnvACL* pCollisionEnvAcl =
+                    dynamic_cast<const collision_detection::CollisionEnvACL*>(planning_scene->getCollisionEnv().get());
+                assert(pCollisionEnvAcl != nullptr && "Expected collision env of type CollisionEnvACL");
+
+                std::vector<moveit::core::RobotState> prefixStates = pCollisionEnvAcl->getUnstuckPath(start_state);
+                // if prefixStates is non-empty, first node is the start state and last node is the un-collided state
+                if (prefixStates.size() > 1) {
+                    // set updated start state to last prefix entry
+                    start_state = prefixStates.back();
+                    prefixStates.pop_back();
+
+                    planning_interface::MotionPlanRequest req2 = req;
+                    moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
+                    bool solved = planner(planning_scene, req2, res);
+                    ROS_INFO_STREAM_NAMED(LOGNAME, "Planning with updated start state returned " <<
+                        std::boolalpha << solved);
+
+                    if (solved && !res.trajectory_->empty())
+                    {
+                        size_t initialWayPointCount = res.trajectory_->getWayPointCount();
+                        // heuristically decide a duration offset for the trajectory (induced by the additional point added as a
+                        // prefix to the computed trajectory)
+                        res.trajectory_->setWayPointDurationFromPrevious(
+                            0, std::min(max_dt_offset_, res.trajectory_->getAverageSegmentDuration()));
+                        // TODO: there's an opportunity to optimize these vector operations
+                        for (auto prefix_state : prefixStates) {
+                            res.trajectory_->addPrefixWayPoint(prefix_state, 0.0);
+                            // we add a prefix point, so we need to bump any previously added index positions
+                            for (std::size_t &added_index : added_path_index)
+                                added_index++;
+                            added_path_index.push_back(0);
+                        }
+                        ROS_INFO_STREAM_NAMED(LOGNAME, "Planning with updated start state" <<
+                            ", initialWaypoints: " << initialWayPointCount <<
+                            ", finalWayPoints: " << res.trajectory_->getWayPointCount());
+                    }
+                    return solved;
+                } else {
+                    ROS_WARN_STREAM_NAMED(LOGNAME, "Callback returned " << prefixStates.size() <<
+                        " prefix states. Passing the original planning request to the planner.");
+                    return planner(planning_scene, req, res);
+                }
+            }
+            else
+            {
+                if (creq.group_name.empty())
+                    ROS_INFO_NAMED(LOGNAME, "Start state is valid");
+                else
+                    ROS_INFO_STREAM_NAMED(LOGNAME, "Start state is valid with respect to group " << creq.group_name);
+                return planner(planning_scene, req, res);
+            }
         }
 
     private:
+        double max_dt_offset_;
     };
+
+const std::string AivotFixStartStateCollision::DT_PARAM_NAME = "start_state_max_dt";
 }  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AivotFixStartStateCollision,

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/aivot_fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/aivot_fix_start_state_collision.cpp
@@ -1,0 +1,39 @@
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+#include <class_loader/class_loader.hpp>
+#include <ros/ros.h>
+
+namespace default_planner_request_adapters
+{
+    static const std::string LOGNAME("AivotCollisionAdapter");
+
+    class AivotFixStartStateCollision : public planning_request_adapter::PlanningRequestAdapter
+    {
+    public:
+        AivotFixStartStateCollision()
+                : planning_request_adapter::PlanningRequestAdapter()
+        {}
+
+        void initialize(const ros::NodeHandle& nh) override
+        {
+            ROS_INFO_NAMED(LOGNAME, "Initializing '%s'", getDescription().c_str());
+        }
+
+        std::string getDescription() const override
+        {
+            return "(Aivot) Fix Start State In Collision";
+        }
+
+        bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                          const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
+                          std::vector<std::size_t>& added_path_index) const override
+        {
+            ROS_INFO_NAMED(LOGNAME, "Running '%s'", getDescription().c_str());
+            return planner(planning_scene, req, res);
+        }
+
+    private:
+    };
+}  // namespace default_planner_request_adapters
+
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AivotFixStartStateCollision,
+                            planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -25,6 +25,11 @@
     </description>
   </class>
 
+  <class name="default_planner_request_adapters/AivotFixStartStateCollision" type="default_planner_request_adapters::AivotFixStartStateCollision" base_class_type="planning_request_adapter::PlanningRequestAdapter">
+    <description>
+    </description>
+  </class>
+
   <class name="default_planner_request_adapters/ResolveConstraintFrames" type="default_planner_request_adapters::ResolveConstraintFrames" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
       Resolves constraints that are defined in collision objects or subframes to robot links, because the former are not known to the planner.


### PR DESCRIPTION
Create an Aivot-specific start state collision adapter, which uses BFS search to find a path to an unstuck state nearby.